### PR TITLE
fall back to using native routing directly

### DIFF
--- a/client/api/endpoints/crd.api.ts
+++ b/client/api/endpoints/crd.api.ts
@@ -62,7 +62,7 @@ export class CustomResourceDefinition extends KubeObject {
 
   getResourceApiBase() {
     const { version, group } = this.spec;
-    return `/crd/apis/${group}/${version}/${this.getPluralName()}`
+    return `/apis/${group}/${version}/${this.getPluralName()}`
   }
 
   getPluralName() {


### PR DESCRIPTION
The backend uses dynamic routing to solve the problem of requesting multiple versions and multiple resources
@hopechans 