### PR TITLE
fix babelrc not exists && not exist dockerignore file

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+    "plugins": [
+      "macros",
+      "@babel/plugin-transform-runtime",
+    ],
+    "presets": [
+      "@babel/preset-env",
+      "@babel/preset-react"
+    ]
+  }

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.idea
+node_modules/
+build/
+dist/
+wireframes/
+backup
+npm-debug.log
+.vscode
+.env
+/tslint.json
+*.DS_Store
+docker-compose.yml
+.git


### PR DESCRIPTION
The lack of files will cause the development environment to fail and the cache cannot be used when building the image